### PR TITLE
liri-shell, liri-eglfs: Fix missing private headers of qtbase

### DIFF
--- a/liri-eglfs/liri-eglfs.spec
+++ b/liri-eglfs/liri-eglfs.spec
@@ -25,6 +25,9 @@ BuildRequires:  pkgconfig(xkbcommon)
 BuildRequires:  pkgconfig(libdrm)
 BuildRequires:  pkgconfig(gbm)
 BuildRequires:  liri-rpm-macros
+%if 0%{?fedora} >= 30
+BuildRequires:  qt5-qtbase-private-devel
+%endif
 
 %description
 This package includes a Qt platform plugin with support for kms and DRM.

--- a/liri-shell/liri-shell.spec
+++ b/liri-shell/liri-shell.spec
@@ -34,6 +34,9 @@ BuildRequires:  libliri-devel
 BuildRequires:  qt5-qtgsettings-devel
 BuildRequires:  liri-eglfs-devel
 #BuildRequires:  pipewire-devel
+%if 0%{?fedora} >= 30
+BuildRequires:  qt5-qtbase-private-devel
+%endif
 
 Requires:       qt5-qtsvg
 Requires:       qt5-qttools


### PR DESCRIPTION
Recent Fedora 30 and Rawhide provides new package 'qt5-qtbase-private-devel'  for installation of Qt5 base private headers. This cause build error of liri-eglfs and liri-shell rpms with current .spec file. 

Build result with this patch:
liri-shell: https://copr.fedorainfracloud.org/coprs/kenya888/liri-nightly/build/910091/
liri-eglfs: https://copr.fedorainfracloud.org/coprs/kenya888/liri-nightly/build/910090/